### PR TITLE
Added google keep

### DIFF
--- a/res/values/arrays.xml
+++ b/res/values/arrays.xml
@@ -37,6 +37,7 @@
         <item>Calendar</item>
         <item>Tasks</item>
         <item>Docs/Drive</item>
+        <item>Keep</item>
         <item>Maps</item>
         <item>Voice</item>
         <item>Accounts</item>
@@ -51,6 +52,7 @@
         <item>https://calendar.google.com</item>
         <item>https://mail.google.com/tasks</item>
         <item>https://drive.google.com</item>
+        <item>https://drive.google.com/keep</item>
         <item>https://maps.google.com</item>
         <item>https://www.google.com/voice/m/</item>
         <item>https://accounts.google.com</item>


### PR DESCRIPTION
Google keep is unfortunately not accessible from google drive itself, hence a separate item is needed.
